### PR TITLE
Add Dockerfile for Render deployment

### DIFF
--- a/resume-ai-backend/.dockerignore
+++ b/resume-ai-backend/.dockerignore
@@ -1,0 +1,4 @@
+target/
+.mvn/
+mvnw
+mvnw.cmd

--- a/resume-ai-backend/Dockerfile
+++ b/resume-ai-backend/Dockerfile
@@ -1,0 +1,13 @@
+# ---- Build stage ----
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -e -DskipTests package
+
+# ---- Runtime stage ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build target/*.jar app.jar
+EXPOSE 8080
+CMD ["sh", "-c", "java -Dserver.port=$PORT -jar app.jar"]


### PR DESCRIPTION
## Summary
- add Dockerfile defining Maven build stage and JRE runtime for backend
- ignore Maven wrapper artifacts in Docker context

## Testing
- `docker build -t resume-ai-backend .` *(fails: command not found)*
- `docker run -p 8080:8080 resume-ai-backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b817bbfba08320ae690c27995abc19