### PR TITLE
fix Dockerfile path for jar

### DIFF
--- a/resume-ai-backend/Dockerfile
+++ b/resume-ai-backend/Dockerfile
@@ -8,6 +8,6 @@ RUN mvn -e -DskipTests package
 # ---- Runtime stage ----
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY --from=build target/*.jar app.jar
+COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080
 CMD ["sh", "-c", "java -Dserver.port=$PORT -jar app.jar"]


### PR DESCRIPTION
## Summary
- fix runtime Dockerfile COPY path to use absolute /app/target

## Testing
- `docker build -t resume-ai-backend resume-ai-backend` *(fails: bash: command not found: docker)*
- `docker run -p 8080:8080 resume-ai-backend` *(fails: bash: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b81aae78f483209ebbe31736c193b8