### PR TITLE
Refactor prompt loading in backend

### DIFF
--- a/resume-ai-backend/src/main/java/com/resume/backend/service/ResumeServiceImpl.java
+++ b/resume-ai-backend/src/main/java/com/resume/backend/service/ResumeServiceImpl.java
@@ -1,15 +1,14 @@
 package com.resume.backend.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.JSONObject;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,8 +37,10 @@ public class ResumeServiceImpl implements ResumeService {
 
 
     String loadPromptFromFile(String filename) throws IOException {
-        Path path = new ClassPathResource(filename).getFile().toPath();
-        return Files.readString(path);
+        ClassPathResource resource = new ClassPathResource(filename);
+        try (InputStream in = resource.getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 
     String putValuesToTemplate(String template, Map<String, String> values) {


### PR DESCRIPTION
## Summary
- use InputStream with StandardCharsets to load prompt templates

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `docker build -t backend .` *(fails: command not found: docker)*
- `curl --location 'https://ai-based-resume-generator.onrender.com/api/v1/resume/generate' --header 'Content-Type: application/json' --data '{"userDescription":"i am a java spring boot developer . have experience of 3 years ."}'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b81fb898cc8320aee0ea21abe99478